### PR TITLE
"Update the resources allocated to build"

### DIFF
--- a/openshift/templates/frontend/frontend-build.json
+++ b/openshift/templates/frontend/frontend-build.json
@@ -57,7 +57,16 @@
                         "name": "${NAME}-artifacts:${OUTPUT_IMAGE_TAG}"
                     }
                 },
-                "resources": {}
+                "resources": {
+                    "limits": {
+                        "cpu": "2",
+                        "memory": "3Gi"
+                    },
+                    "requests": {
+                        "cpu": "1",
+                        "memory": "2Gi"
+                    }
+                }
             }
         },
         {


### PR DESCRIPTION
made a small change to the build.  It was failing to run build because we didn't have enough resources allocated... so the VM didn't run it with enough memory/cpu...