### PR TITLE
Improve and correct factum and reply book popups:

### DIFF
--- a/src/components/ExpandableInfoPopupSection.js
+++ b/src/components/ExpandableInfoPopupSection.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import './infopopup.css';
 import InfoPopupIcon from "./InfoPopupIcon";
+import Deadline from './infopopups/Deadline';
 
 class ExpandableInfoPopupSection extends Component {
 
     constructor(props) {
         super(props);
-        this.state= this.initialState();
+        this.state= this.initialState(props.expanded);
         this.initialState= this.initialState.bind(this);
         this.toggleSection = this.toggleSection.bind(this);
     }
@@ -63,7 +64,10 @@ class ExpandableInfoPopupSection extends Component {
 
         let deadline = null;
         if (this.props.deadline) {
-            deadline = <div className="deadline">{this.props.deadline}</div>;
+            deadline = <Deadline
+                        deadlinePhrase={this.props.deadlinePhrase}
+                        deadline={this.props.deadline}
+                />
         }
 
         return (
@@ -86,11 +90,17 @@ class ExpandableInfoPopupSection extends Component {
                     <div className={this.state.replacementHeadingClass}>
                         <div className="row ">
                             <div className=" col col-lg-9 col-md-9 col-sm-9" >
-                                {deadline}
-                                <div className="info-modal-section-heading">{this.props.expandedHeading}</div>
+                                <div className="info-modal-section-heading">
+                                    {this.props.sectionHeading}
+                                 </div>
                             </div>
                             <div className="col col-lg-3 col-md-3 col-sm-3 toggle-expansion-button" onClick={this.toggleSection}>
                                 <i className="fa fa-minus" />
+                            </div>
+                        </div>
+                        <div className="row ">
+                            <div className=" col col-lg-12 col-md-12 col-sm-12" >
+                                {deadline}
                             </div>
                         </div>
                     </div>
@@ -132,13 +142,22 @@ class ExpandableInfoPopupSection extends Component {
 
     }
 
-    initialState() {
-        return {
-            promptClass: "col col-lg-11 col-md-11 content-showing",
-            replacementHeadingClass: "col col-lg-11 col-md-11 content-hidden",
-            detailsClass: "row content-hidden",
-            expanded: false
-        };
+    initialState(expandIt) {
+        if (expandIt) {
+            return {
+                promptClass: "col col-lg-11 col-md-11 content-hidden",
+                replacementHeadingClass: "col col-lg-11 col-md-11 content-showing",
+                detailsClass: "row content-showing",
+                expanded: true
+            };
+        } else {
+            return {
+                promptClass: "col col-lg-11 col-md-11 content-showing",
+                replacementHeadingClass: "col col-lg-11 col-md-11 content-hidden",
+                detailsClass: "row content-hidden",
+                expanded: false
+            };
+        }
     }
 }
 export default ExpandableInfoPopupSection;

--- a/src/components/InfoPopup.js
+++ b/src/components/InfoPopup.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import './infopopup.css';
 import InfoPopupSection from './InfoPopupSection';
 import ExpandableInfoPopupSection from './ExpandableInfoPopupSection';
-import FactumPopup from "./infopopups/FactumPopup";
+import AppellantFactumPopup from "./infopopups/AppellantFactumPopup";
 import ReplyBookPopup from "./infopopups/ReplyBookPopup";
 
 class InfoPopup extends Component {
@@ -11,7 +11,7 @@ class InfoPopup extends Component {
         if (this.props.show) {
             switch (this.props.type) {
                 case 'factum' :
-                    return <FactumPopup
+                    return <AppellantFactumPopup
                         close={this.props.close}
                         getSections={this.getSections.bind(this)}
                     />;
@@ -34,36 +34,17 @@ class InfoPopup extends Component {
             if (!sectionProps.expandable) {
                 return (
                     <InfoPopupSection
-                        key={key}
-                        sectionHeading={sectionProps.sectionHeading}
-                        iconSrc={sectionProps.iconSrc}
-                        iconClass={sectionProps.iconClass}
-                        deadline={sectionProps.deadline}
-                        lineHeight={sectionProps.lineHeight}
-                        last={sectionProps.last}
-                        helpSection={sectionProps.helpSection}
-                        helpURL={sectionProps.helpURL}
-                        helpURLName={sectionProps.helpURLName}
-                        contentMap={sectionProps.contentMap}
-                        getListContent={this.getListContent.bind(this)}
+                        key={ key }
+                        { ...sectionProps }
+                        getListContent={ this.getListContent.bind(this) }
                     />
                 )
             } else {
                 return (
                     <ExpandableInfoPopupSection
-                        key={key}
-                        sectionHeading={sectionProps.sectionHeading}
-                        iconSrc={sectionProps.iconSrc}
-                        iconClass={sectionProps.iconClass}
-                        expandedHeading={sectionProps.expandedHeading}
-                        lineHeight={sectionProps.lineHeight}
-                        deadline={sectionProps.deadline}
-                        helpSection={sectionProps.helpSection}
-                        helpURL={sectionProps.helpURL}
-                        helpURLName={sectionProps.helpURLName}
-                        last={sectionProps.last}
-                        contentMap={sectionProps.contentMap}
-                        getListContent={this.getListContent.bind(this)}
+                        key={ key }
+                        { ...sectionProps }
+                        getListContent={ this.getListContent.bind(this) }
                     />
 
                 )

--- a/src/components/InfoPopupSection.js
+++ b/src/components/InfoPopupSection.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import './infopopup.css';
 import InfoPopupIcon from './InfoPopupIcon';
+import Deadline from './infopopups/Deadline';
 
 class InfoPopupSection extends Component {
 
@@ -8,7 +9,10 @@ class InfoPopupSection extends Component {
 
         let deadline = null;
         if (this.props.deadline) {
-            deadline = <div className="deadline">{this.props.deadline}</div>;
+            deadline = <Deadline
+                deadlinePhrase={this.props.deadlinePhrase}
+                deadline={this.props.deadline}
+            />
         }
 
         let verticalLine = null;
@@ -62,10 +66,10 @@ class InfoPopupSection extends Component {
                     <div className="col col-lg-11 col-md-11 col sm-11 top-deadline">
                         <div className="row">
                             <div className="col col-lg-12 col-md-12 col-sm-12">
-                                {deadline}
                                 <div className="info-modal-section-heading">
                                     {this.props.sectionHeading}
                                 </div>
+                                {deadline}
                             </div>
                         </div>
                     </div>

--- a/src/components/Journey.js
+++ b/src/components/Journey.js
@@ -117,7 +117,6 @@ class Journey extends Component {
                 mapSrc: "images/journeymap/journey-map_respondent-notice-of-appeal.png",
                 mapProps: [
                     {coords: "75,20,180,200", href: "/form.2.html", alt: "e-file a notice of appearance"},
-                    {coords: "465,15,580,210", function: 'factum', alt: "info about the factum"}
                     ]
             }
         }, () => {

--- a/src/components/JourneyMap.js
+++ b/src/components/JourneyMap.js
@@ -55,7 +55,6 @@ class JourneyMap extends React.Component {
     }
 
     openInfoModal(popupType) {
-        console.log("popup type", popupType);
         this.setState({showInfoModal:true, popupType: popupType});
     }
 

--- a/src/components/infopopup.css
+++ b/src/components/infopopup.css
@@ -3,7 +3,7 @@
     color: white;
     margin: auto;
     padding: 20px;
-    width: 65%;
+    width: 60%;
     font-size: 2em;
     min-width: 800px;
 }
@@ -13,13 +13,15 @@
     margin: auto;
     padding: 22px 20px 40px 20px;
     border: 1px solid #888;
-    width: 65%;
+    width: 60%;
     min-width: 800px;
+    font-size: 16px;
 }
 
 .info-modal-section-heading {
-    padding-bottom: 20px;
+    padding-bottom: 15px;
     padding-top: 15px;
+    font-weight: bolder;
 }
 
 .info-modal-section {
@@ -46,7 +48,7 @@
 }
 
 .bullet-list-row {
-    margin: 5px;
+    margin: 5px 0 5px 5px;
     paddingLeft: 20px;
     font-weight: normal;
 }
@@ -83,14 +85,26 @@
 
 .info-modal-ol {
     font-weight: bolder;
-    padding: 10px 10px 10px 0;
+    padding: 25px 10px 10px 0;
 }
 
 .deadline {
+    display: flex;
+    flex-flow: wrap;
+    align-content: space-evenly;
+    background-color: #ffe9b0;
+    padding: 15px;
+    border-radius: 10px;
+}
+
+.deadline-quantity {
     color: red;
-    font-size: 3.5rem;
-    margin-bottom: -15px;
-    padding-top: 7px;
+    padding: 0 5px;
+}
+
+.deadline-alert {
+    font-size: 2.2rem;
+    margin-right: 15px;
 }
 
 .vertical-line {
@@ -121,7 +135,7 @@
     font-size: xx-large;
     font-weight: bolder;
     color: grey;
-    text-align: left;
+    text-align: right;
     cursor: pointer;
 }
 

--- a/src/components/infopopups/AppellantFactumPopup.js
+++ b/src/components/infopopups/AppellantFactumPopup.js
@@ -1,7 +1,7 @@
 import React, { Component }from 'react';
 import '../infopopup.css';
 
-class FactumPopup extends Component {
+class AppellantFactumPopup extends Component {
 
     constructor(props) {
         super(props);
@@ -10,7 +10,7 @@ class FactumPopup extends Component {
                 line: "Complete either the .DOCs or .PDFs below:",
                 rows: [
                     { description: "Factum (Form 10)", times: "4 x", link1: "DOC", link2: "PDF" },
-                    { description: " Optional - Transcript and Extract Book (Form 13)", times: "1 x", link1: "DOC", link2: "PDF" },
+                    { description: "*Optional - Transcript and Extract Book (Form 13)", times: "1 x", link1: "DOC", link2: "PDF" },
                     { description: "Appeal Book (Form 12)", times: "4 x", link1: "DOC", link2: "PDF" },
                 ]
             },
@@ -20,7 +20,7 @@ class FactumPopup extends Component {
 
         let contentMap2 = [
             {
-                line: "If you would like to reply, please complete either the .DOC or .PDF document below:",
+                line: "IF you would like to reply, please complete either the .DOC or .PDF document below:",
                 rows: [{description: "Reply (Form 11)", times: "4x", link1: "DOC", link2: "PDF"}]
             },
             "File the indicated number of copies to the registry.",
@@ -28,23 +28,28 @@ class FactumPopup extends Component {
         ];
 
         this.sections = [{
-            expandable: false,
-            sectionHeading: "Filing and service deadline after filing the Appeal Record",
-            iconSrc: "icons/icon-clock.svg",
-            iconClass: "info-modal-clock",
-            deadline: "30 days",
-            lineHeight: '225px',
+            expandable: true,
+            sectionHeading: "Have you filed an Appeal Record ?",
+            iconSrc: "icons/icon-share.svg",
+            iconClass: "info-modal-icon",
+            deadlinePhrase: {first: "File a Factum and Appeal Book ", last: " of filing an Appeal Record."},
+            helpSection: false,
+            helpURL: null,
+            helpURLName: null,
+            deadline: " within 30 days ",
+            lineHeight: '243px',
             last: false,
+            expanded: true,
             contentMap: contentMap
         }, {
             expandable: true,
             sectionHeading: "Were you served with a respondent's Factum?",
-            expandedHeading: "Filing and service deadline after receiving the Factum",
             iconSrc :"icons/icon-share.svg",
             iconClass: "info-modal-icon",
-            deadline:"7 days",
+            deadline:" within 7 days ",
+            deadlinePhrase: {first: "File and serve a Reply ", last: " of receiving a Respondent's Factum."},
             content: true,
-            lineHeight: '172px',
+            lineHeight: '187px',
             helpSection: false,
             helpURL: null,
             helpURLName: null,
@@ -58,7 +63,8 @@ class FactumPopup extends Component {
             iconSrc: "icons/icon-info.svg",
             iconClass: "info-modal-icon",
             deadline: null,
-            content: null,
+            content: " You may also be served a copy of the respondent’s Transcript Extract Book.  " +
+            " This document is for your awareness only and you do not have to respond to it.",
             lineHeight: null,
             VLProps: null,
             helpSection: true,
@@ -86,4 +92,4 @@ class FactumPopup extends Component {
     }
 
 }
-export default FactumPopup;
+export default AppellantFactumPopup;

--- a/src/components/infopopups/Deadline.js
+++ b/src/components/infopopups/Deadline.js
@@ -1,0 +1,23 @@
+import React, {Component} from 'react';
+
+class Deadline extends Component {
+
+    render() {
+        return (
+            <div className="row ">
+                <div className=" col col-lg-12 col-md-12 col-sm-12" style={{padding: 0}} >
+                    <div className="deadline">
+                        <i className="fa fa-exclamation-triangle deadline-alert" />
+
+                        {this.props.deadlinePhrase.first}
+                        <div className="deadline-quantity"> {this.props.deadline} </div>
+                        {this.props.deadlinePhrase.last}
+
+                    </div>
+                </div>
+            </div>
+
+        );
+
+    }
+} export default Deadline;

--- a/src/components/infopopups/ReplyBookPopup.js
+++ b/src/components/infopopups/ReplyBookPopup.js
@@ -18,11 +18,11 @@ class ReplyBookPopup extends Component {
 
         this.sections = [{
             expandable: false,
-            sectionHeading: "Were you served with a Notice of Motion for Leave to Appeal and a Motion Book? " +
-            " File a Reply Book at least 5 days before the hearing.",
-            iconSrc: "icons/icon-clock.svg",
+            sectionHeading: "Were you served with a Notice of Motion for Leave to Appeal and a Motion Book? ",
+            iconSrc: "icons/icon-share.svg",
             iconClass: "info-modal-icon",
-            deadline: " 5 days ",
+            deadline: " at least 5 days ",
+            deadlinePhrase: { first: "File a Reply Book ", last: " before the hearing." },
             lineHeight: null,
             last: true,
             contentMap: contentMap,


### PR DESCRIPTION
- Make the first section expandable, but expanded by default (general…ize later)
- Update the deadline styling
- Tweak the alignment
- Reduce the number of props written into the Popup Section components
- Remove the respondent factum link
- Update the text to match the new factum popup wireframe